### PR TITLE
fix: Lets switchTab switch to other Chrome windows, with focus

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -224,8 +224,13 @@ function getBookmarks() {
 // Lots of different actions
 function switchTab(tab) {
 	chrome.tabs.highlight({
-		tabs: tab.index
+		tabs: tab.index,
+		windowId: tab.windowId
 	})
+	chrome.windows.update(
+		tab.windowId,
+		{ focused: true }
+	)
 }
 function goBack(tab) {
 	chrome.tabs.goBack({


### PR DESCRIPTION
Thanks for this cool extension!

I use multiple Chrome windows on different monitors and noticed that tab search and switch would show all my tabs across every window, but switching would have it switch to whichever tab on the current window had the same index as the desired off-window tab.

This PR fixes that and also focuses the off-window so it pops to the fore.