### PR TITLE
fix: close tab action

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -319,6 +319,9 @@ const closeWindow = (id) => {
 const closeTab = (tab) => {
 	chrome.tabs.remove(tab.id);
 }
+const closeCurrentTab = () => {
+	getCurrentTab().then(closeTab)
+}
 const removeBookmark = (bookmark) => {
 	chrome.bookmarks.remove(bookmark.id);
 }
@@ -394,6 +397,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 			break;
 		case "close-window":
 			closeWindow(sender.tab.windowId);
+			break;
+		case "close-tab":
+			closeCurrentTab();
 			break;
 		case "search-history":
 			chrome.history.search({text:message.query, maxResults:1000, startTime:31536000000*5}).then((data) => {

--- a/src/content.js
+++ b/src/content.js
@@ -210,9 +210,6 @@ $(document).ready(function(){
 				case "scroll-top":
 					window.scrollTo(0,0);
 					break;
-				case "close-tab":
-					window.close();
-					break;
 				case "navigation":
 					if (e.ctrlKey) {
 						window.open(action.url);


### PR DESCRIPTION
Hi! For security reasons `window.close()` doesn't work on tabs that haven't been opened by the same script, which was causing an error when trying to close the current tab.

![image](https://user-images.githubusercontent.com/77246331/149623771-15ce01a3-6e16-4963-b607-1223b6587ceb.png)

I have added a function to close the tab from the `background.js`  using the chrome API.

Thank you for this awesome extension 🚀
