### PR TITLE
fix: history search not working

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -127,7 +127,7 @@ $(document).ready(function(){
 			var tempvalue = value.replace("/history ", "");
 			var query = "";
 			if (tempvalue != "/history") {
-				query = value.replace("/history " + " ", "");
+				query = value.replace("/history ", "");
 			}
 			chrome.runtime.sendMessage({request:"search-history", query:query}, function(response){
 				populateOmniFilter(response.history);


### PR DESCRIPTION
Thanks for the great extension!

Omni's history search has not worked for me.
I think it is due to concatenating strings that are not needed.